### PR TITLE
Handle loss of serial, Mongo and Websocket

### DIFF
--- a/ventilator_serial.py
+++ b/ventilator_serial.py
@@ -15,7 +15,6 @@ class SerialHandler():
         self.port = port
         self.baudrate = baudrate
         self.ser = None
-
         self.request_queue = request_queue
         self.db_queue = db_queue # Enqueue to
         self.out_queue = out_queue
@@ -170,4 +169,5 @@ class SerialHandler():
             except Exception as e:
                 print(e)
                 traceback.print_exc()
+
 

--- a/ventilator_websocket.py
+++ b/ventilator_websocket.py
@@ -75,7 +75,6 @@ class WebsocketHandler():
 
     def __init__(self, serial_queue, addr='localhost', port=3001):
         self.url = "ws://" + addr + ":" + str(port) + "/"
-
         self.id = 1
         self.serial_queue = serial_queue
 


### PR DESCRIPTION
We can lose any of these connections. If we encounter the case where we lose one
of these connections we attempt to resotore the connection.

Handles the following cases:
- Arduino is disconnected
- Mongodb is shut down
- Front-end server is shut down

Signed-off-by: Frank Vanbever <frank.vanbever@gmail.com>