### PR TITLE
Test python_daemon without the need of arduino

### DIFF
--- a/daemon.py
+++ b/daemon.py
@@ -11,6 +11,7 @@ This daemon has a number of tasks
 import threading
 import queue
 import time
+import sys
 import multiprocessing as mp
 from ventilator_database import DbClient
 from ventilator_serial import SerialHandler
@@ -26,6 +27,9 @@ def run():
     """
     Do setup and start threads
     """
+    userport = None
+    if len(sys.argv) > 1:
+        userport = sys.argv[1]
 
     api_request = APIRequest("http://localhost:3001")
     api_request.send_setting("startPythonDaemon", datetime.utcnow())
@@ -35,7 +39,10 @@ def run():
     alarm_input_queue = mp.Queue() # Queue for values for Alarm thread
     request_queue = mp.Queue() # Queue with the requests to be sent to the API
 
-    ser_handler = SerialHandler(db_queue, request_queue, serial_output_queue, alarm_input_queue)
+    if userport:
+        ser_handler = SerialHandler(db_queue, request_queue, serial_output_queue, alarm_input_queue, port = userport)
+    else:
+        ser_handler = SerialHandler(db_queue, request_queue, serial_output_queue, alarm_input_queue)
     db_handler = DbClient(db_queue)
     websocket_handler = WebsocketHandler(serial_output_queue)
     alarm_handler = AlarmHandler(alarm_input_queue,serial_output_queue, request_queue)

--- a/dummyPrint/dummyPrint.py
+++ b/dummyPrint/dummyPrint.py
@@ -11,19 +11,24 @@ def dummyPrint(device):
     ser.open()
     while True:
         flag = 0
-        ser.write("BPM=100\n".encode('utf-8'))
-        ser.write("VOL=200\n".encode('utf-8'))
-        ser.write("TRIG=0\n".encode('utf-8'))
-        ser.write("PRES=20\n".encode('utf-8'))
-        if ser.in_waiting > 0:
-            rcv = ser.read()
-            if rcv == 'T':
-                flag = 1
-            rcv = ser.read()
-        if flag == 1:
-            ser.write("OK\n".encode('utf-8'))
-        else:
-            ser.write("NOK\n".encode('utf-8'))
+        try:
+            ser.write("BPM=100\n".encode('utf-8'))
+            ser.write("VOL=200\n".encode('utf-8'))
+            ser.write("TRIG=0\n".encode('utf-8'))
+            ser.write("PRES=20\n".encode('utf-8'))
+            if ser.in_waiting > 0:
+                rcv = ser.read()
+                if rcv == 'T':
+                    flag = 1
+                rcv = ser.read()
+            if flag == 1:
+                ser.write("OK\n".encode('utf-8'))
+            else:
+                ser.write("NOK\n".encode('utf-8'))
+        except:
+            print("Serial disconnected or not available")
+            ser.close()
+            break
         time.sleep(0.1)
 
 if __name__ == "__main__":

--- a/dummyPrint/dummyPrint.py
+++ b/dummyPrint/dummyPrint.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python3
+
+import sys
+import serial
+import time
+
+def dummyPrint(device):
+    print(device)
+    ser = serial.Serial(device, 115200, timeout=1)
+    ser.close()
+    ser.open()
+    while True:
+        flag = 0
+        ser.write("BPM=100\n".encode('utf-8'))
+        ser.write("VOL=200\n".encode('utf-8'))
+        ser.write("TRIG=0\n".encode('utf-8'))
+        ser.write("PRES=20\n".encode('utf-8'))
+        if ser.in_waiting > 0:
+            rcv = ser.read()
+            if rcv == 'T':
+                flag = 1
+            rcv = ser.read()
+        if flag == 1:
+            ser.write("OK\n".encode('utf-8'))
+        else:
+            ser.write("NOK\n".encode('utf-8'))
+        time.sleep(0.1)
+
+if __name__ == "__main__":
+    if len(sys.argv) >= 2:
+        dummyPrint(sys.argv[1])

--- a/dummyPrint/test_pty.sh
+++ b/dummyPrint/test_pty.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# Test: Create pty devices in /tmp/ttySIM1 /tmp/ttySIM2 and run
+# daemon.py and dummyPrint.py with them as argument
+#
+
+trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
+
+socat -d -d PTY,raw,echo=0,link=/tmp/ttySIM1 PTY,raw,echo=0,link=/tmp/ttySIM2 &
+
+../daemon.py /tmp/ttySIM2 &
+
+./dummyPrint.py /tmp/ttySIM1

--- a/ventilator_serial.py
+++ b/ventilator_serial.py
@@ -45,36 +45,42 @@ class SerialHandler():
                 self.ser.write(bytes(msg_out, 'ascii'))
 
 
-            line = self.ser.readline()
             try:
-                line = line.decode('utf-8')
-            except UnicodeDecodeError:
-                print("Failure decoding serial message, continuing")
-                if self.errorcounter == 0:
-                    self.errorcounter += 1
-                    print("utf-8 decode errorcounter: {}".format(self.errorcounter))
-                    continue
-                else:
-                    print("Repeatedly unable to decode serial messages, aborting!")
-                # TODO: At the start it can happen that we get an incorrect message
-                # due to incomplete data. I do a hard abort here to ensure that this only
-                # happens once. We need to determine what a tolerable level of failure is here.
+                line = self.ser.readline()
+            except:
+                print("Failure reading from serial port")
+                line = None
+
+            if line:
+                try:
+                    line = line.decode('utf-8')
+                except UnicodeDecodeError:
+                    print("Failure decoding serial message, continuing")
+                    if self.errorcounter == 0:
+                        self.errorcounter += 1
+                        print("utf-8 decode errorcounter: {}".format(self.errorcounter))
+                        continue
+                    else:
+                        print("Repeatedly unable to decode serial messages, aborting!")
+                    # TODO: At the start it can happen that we get an incorrect message
+                    # due to incomplete data. I do a hard abort here to ensure that this only
+                    # happens once. We need to determine what a tolerable level of failure is here.
 
 
-            tokens = line.split('=', 1)
-            val = tokens[-1].rstrip('\r\n')
+                tokens = line.split('=', 1)
+                val = tokens[-1].rstrip('\r\n')
 
-            if line.startswith(ventilator_protocol.alarm + '='):
-                self.alarm_queue.put({'type': 'ALARM', 'val': val})
+                if line.startswith(ventilator_protocol.alarm + '='):
+                    self.alarm_queue.put({'type': 'ALARM', 'val': val})
 
 
-            # handle measurements
-            for type in ventilator_protocol.measurements:
-                if line.startswith((type + '=')):
-                    self.queue_put(type, val)
+                # handle measurements
+                for type in ventilator_protocol.measurements:
+                    if line.startswith((type + '=')):
+                        self.queue_put(type, val)
 
-            # handle settings
-            for type in ventilator_protocol.settings:
-                if line.startswith((type + '=')):
-                    # Verify that the checksum is correct.
-                    pass
+                # handle settings
+                for type in ventilator_protocol.settings:
+                    if line.startswith((type + '=')):
+                        # Verify that the checksum is correct.
+                        pass


### PR DESCRIPTION
Simulate arduino code from python script connected via pty interface
A pty device pair can be created using socat:

> socat -d -d PTY,raw,echo=0 PTY,raw,echo=0
> 2020/03/30 13:25:41 socat[12517] N PTY is /dev/pts/4
> 2020/03/30 13:25:41 socat[12517] N PTY is /dev/pts/5
> 2020/03/30 13:25:41 socat[12517] N starting data transfer loop with FDs [5,5] and [7,7]

Add the path to each device as argument to both daemon and dummyPrint.py